### PR TITLE
Use FnMut for watch closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# Version 0.4.4 (2020-11-19)
+
+- `watch` now accepts `FnMut` instead of `Fn`
+
 # Version 0.4.3 (2019-12-03)
 
 - Added `blocking` API.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotwatch"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Francesca Lovebloom <francesca@brainiumstudios.com>"]
 edition = "2018"
 description = "A Rust library for conveniently watching and handling file changes."

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -141,7 +141,7 @@ impl Hotwatch {
             match self.rx.recv() {
                 Ok(event) => {
                     util::log_event(&event);
-                    if let Some(handler) = util::handler_for_event(&event, &self.handlers) {
+                    if let Some(handler) = util::handler_for_event(&event, &mut self.handlers) {
                         if let Flow::Exit = handler(event) {
                             break;
                         }


### PR DESCRIPTION
### Summary

This patch implements a non-breaking API change to accept `FnMut` closures instead of `Fn` closures.

### Reasoning

Consider the use case where we're caching the `File` reference externally outside the closure, and we're looking for updates on a file for write and create:
```rust
  let ConfigData { path, mut file } = config_data;
  let watch_result = watch.watch(&path, move |e: Event| {
    match e {
      Event::Write(_) | Event::Create(_) => { /* do work here */ }
      _ => debug!("Saw event {:#?} but ignored it", e),
    }
  });
```

Unfortunately, the above implementation is bugged as `file` becomes stale when the file is buffer-swapped (e.g. saving through `nvim`). This means once we get a `Event::Create(_)`, we need to re-create `file` instance as reading from it will always return an empty value:

```rust
  let ConfigData { path, mut file } = config_data;
  let watch_result = watch.watch(&path, move |e: Event| {
    if let Event::Create(ref path) = e {
      file = load_custom_path_config(path)
        .expect("file to exist at path")
        .file;
    }

    match e {
      Event::Write(_) | Event::Create(_) => { /* do work here */ }
      _ => debug!("Saw event {:#?} but ignored it", e),
    }
  });
```

However, this necessarily requires mutation of `file`, which isn't possible as the closure is defined as `Fn` instead of `FnMut`.

### Notes

- This should be a non-breaking change as `FnMut` is a supertrait of `Fn`.
- Primary logic change should be in `find_handler`, which now checks if the key exists and immediate returns a mutable reference if it finds one. The remaining changes are simply conforming to the type change.