### PR TITLE
Use FnMut in blocking implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# Version 0.4.5 (2020-11-25)
+
+- The blocking implementation of `watch` now also accepts `FnMut` instead of `Fn`.
+
 # Version 0.4.4 (2020-11-19)
 
 - `watch` now accepts `FnMut` instead of `Fn`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotwatch"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Francesca Lovebloom <francesca@brainiumstudios.com>"]
 edition = "2018"
 description = "A Rust library for conveniently watching and handling file changes."

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -32,7 +32,7 @@ impl Default for Flow {
 /// Dropping this will unwatch everything.
 pub struct Hotwatch {
     watcher: notify::RecommendedWatcher,
-    handlers: HashMap<PathBuf, Box<dyn Fn(Event) -> Flow>>,
+    handlers: HashMap<PathBuf, Box<dyn FnMut(Event) -> Flow>>,
     rx: Receiver<Event>,
 }
 
@@ -111,7 +111,7 @@ impl Hotwatch {
     pub fn watch<P, F>(&mut self, path: P, handler: F) -> Result<(), Error>
     where
         P: AsRef<Path>,
-        F: 'static + Fn(Event) -> Flow,
+        F: 'static + FnMut(Event) -> Flow,
     {
         let absolute_path = path.as_ref().canonicalize()?;
         self.watcher


### PR DESCRIPTION
Following on from #4, this PR makes the blocking implementation of `Hotwatch` use `FnMut` handlers instead of `Fn`.

I added a note to the changelog and bumped the version as advised in #4, please let me know if any other changes are necessary.

Thanks for the handy library!