### PR TITLE
Allow to disable logging by hotwatch crate via a compiler flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,12 @@ readme = "README.md"
 keywords = ["notify", "watch", "events", "filesystem"]
 license = "MIT OR Apache-2.0"
 
+[features]
+default = ["logging"]
+logging = ["dep:log"]
+
 [dependencies]
-log = "0.4"
+log = { version = "0.4", optional = true }
 notify = "6.0"
 notify-debouncer-full = "0.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@
 //! (There's also a [`blocking`] mode, in case you're a big fan of blocking.)
 //!
 //! Only the latest stable version of Rust is supported.
+//!
+//! # Feature Flags
+//! - `logging`: if active then this crate does logging. Is activated by default.
 
 pub mod blocking;
 mod util;

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,15 +4,26 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg_attr(not(feature = "logging"), allow(unused_variables))]
 pub fn log_event(event: &Event) {
+    #[cfg(feature = "logging")]
     log::debug!("received event 🎉: {event:#?}");
 }
 
+#[cfg_attr(not(feature = "logging"), allow(unused_variables))]
 pub fn log_error(err: &notify::Error) {
+    #[cfg(feature = "logging")]
     log::error!("error in event stream: {err}");
 }
 
+#[cfg_attr(not(feature = "logging"), allow(unused_variables))]
+pub fn log_matching_path(path: &Path) {
+    #[cfg(feature = "logging")]
+    log::debug!("matching against {:?}", path);
+}
+
 pub fn log_dead() {
+    #[cfg(feature = "logging")]
     log::debug!("sender disconnected! the watcher is dead 💀");
 }
 
@@ -30,7 +41,7 @@ pub fn handler_for_event<'a, H>(
     ) -> Option<&'a mut H> {
         let mut remaining_path = Some(path);
         while let Some(path) = remaining_path {
-            log::debug!("matching against {:?}", path);
+            log_matching_path(path);
             if handlers.contains_key(path) {
                 return handlers.get_mut(path);
             }


### PR DESCRIPTION
# Motivation:

The logging of this crate can fill the output up pretty fast and therefore it is hard to see applications logs.
Library crates should usually not log beside an application crate.

## What changes by this PR

This PR allows the user to deactivate the logging from this crate by deactivating the compiler flag "logging".

This compiler flag is enabled by default to prevent breaking changes.  

In my opinion this feature should be disabled by default in the future.
The flat is also documented under lib.rs for the rust docs.